### PR TITLE
Update js parsers

### DIFF
--- a/jstp-core/src/main/java/com/metarhia/jstp/core/JSNativeSerializer.java
+++ b/jstp-core/src/main/java/com/metarhia/jstp/core/JSNativeSerializer.java
@@ -1,5 +1,6 @@
 package com.metarhia.jstp.core;
 
+import com.metarhia.jstp.core.JSTypes.JSUndefined;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +31,8 @@ public class JSNativeSerializer {
     } else if (input == null) {
       return builder.append("null");
     }
-    return builder.append("undefined");
+//  } else if (input instanceof JSUndefined) {
+    return builder.append(JSUndefined.get().toString());
   }
 
   public static StringBuilder stringifyNumber(Number value, StringBuilder builder) {

--- a/jstp-core/src/main/java/com/metarhia/jstp/core/JSParsingException.java
+++ b/jstp-core/src/main/java/com/metarhia/jstp/core/JSParsingException.java
@@ -2,23 +2,32 @@ package com.metarhia.jstp.core;
 
 public class JSParsingException extends Exception {
 
-  public JSParsingException(String message) {
-    super(message);
+  private String errMessage;
+
+  public JSParsingException(String errMessage) {
+    super(errMessage);
+    this.errMessage = errMessage;
   }
 
-  public JSParsingException(int index, String errorMsg) {
-    super(String.format("Index: %d, Message: %s", index, errorMsg));
+  public JSParsingException(int index, String errMessage) {
+    super(String.format("Index: %d, Message: %s", index, errMessage));
+    this.errMessage = errMessage;
   }
 
   public JSParsingException(int index, Throwable cause) {
     super(String.format("Index: %d", index), cause);
   }
 
-  public JSParsingException(int index, String errorMsg, Throwable cause) {
-    super(String.format("Index: %d, Message: %s", index, errorMsg), cause);
+  public JSParsingException(int index, String errMessage, Throwable cause) {
+    super(String.format("Index: %d, Message: %s", index, errMessage), cause);
+    this.errMessage = errMessage;
   }
 
   public JSParsingException(Throwable cause) {
     super(cause);
+  }
+
+  public String getErrMessage() {
+    return errMessage;
   }
 }

--- a/jstp-core/src/main/java/com/metarhia/jstp/core/Tokens/Tokenizer.java
+++ b/jstp-core/src/main/java/com/metarhia/jstp/core/Tokens/Tokenizer.java
@@ -51,8 +51,6 @@ public class Tokenizer implements Serializable {
   }
 
   public Token next() throws JSParsingException {
-    prevIndex = index;
-
     if (index >= length) {
       return lastToken = Token.NONE;
     }
@@ -61,6 +59,8 @@ public class Tokenizer implements Serializable {
       ch = input[index];
     } while (++index < length
         && (ch == 0x20 || ch == 0x0a || ch == 0x09)); // space and \n and \t
+
+    prevIndex = index - 1;
 
     if (ch == '/' && input[index] == '/') {
       index = indexOf('\n', index) + 1;

--- a/jstp-core/src/test/java/com/metarhia/jstp/core/JSNativeParserTest.java
+++ b/jstp-core/src/test/java/com/metarhia/jstp/core/JSNativeParserTest.java
@@ -20,7 +20,6 @@ class JSNativeParserTest {
   public static final TestData[] parseTestData = new TestData[]{
       new TestData<>("[,,0]", Arrays.asList(
           JSUndefined.get(), JSUndefined.get(), 0.0)),
-      new TestData<>("", JSUndefined.get()),
       new TestData<>("{nickname: '\\n\\tnyaaaaaa\\'aaa\\'[((:’ –( :-)) :-| :~ =:O)],'}",
           TestUtils.mapOf(
               "nickname", "\n\tnyaaaaaa\'aaa\'[((:’ –( :-)) :-| :~ =:O)],")),
@@ -56,13 +55,17 @@ class JSNativeParserTest {
 
   private static final TestData[] parseThrowTestData = new TestData[]{
       new TestData<>("{he : llo : 123}", new JSParsingException(
-          "Index: 9, Message: Expected ',' as key-value pairs separator")),
-      new TestData<>("{he : llo : 123}", new JSParsingException(
-          "Index: 9, Message: Expected ',' as key-value pairs separator")),
+          "Index: 6, Message: llo is not defined")),
+      new TestData<>("{he : 'llo'  : 123}", new JSParsingException(
+          "Index: 13, Message: Expected ',' as key-value pairs separator")),
       new TestData<>("{'ssssss : }", new JSParsingException(
           "Index: 1, Message: Unmatched quote")),
       new TestData<>("'ssssss", new JSParsingException(
-          "Index: 0, Message: Unmatched quote"))
+          "Index: 0, Message: Unmatched quote")),
+      new TestData<>("{a:", new JSParsingException(
+          "Index: 2, Message: Expected value after ':' in object")),
+      new TestData<>("{a:}", new JSParsingException(
+          "Index: 3, Message: Expected value after ':' in object"))
   };
 
   private JSNativeParser parser;
@@ -76,7 +79,7 @@ class JSNativeParserTest {
     for (TestData<String, Object> td : parseTestData) {
       parser.setInput(td.input);
       Object actual = parser.parse();
-      assertEquals(td.expected, actual);
+      assertEquals(td.expected, actual, "Failed parsing: " + td.input);
     }
   }
 
@@ -85,8 +88,10 @@ class JSNativeParserTest {
     for (TestData<String, JSNativeParser.KeyValuePair> td : parseKeyValuePairTestData) {
       parser.setInput(td.input);
       JSNativeParser.KeyValuePair actual = parser.parseKeyValuePair();
-      assertEquals(td.expected.getKey(), actual.getKey());
-      assertEquals(td.expected.getValue(), actual.getValue());
+      assertEquals(td.expected.getKey(), actual.getKey(),
+          "Failed parsing(key): " + td.input);
+      assertEquals(td.expected.getValue(), actual.getValue(),
+          "Failed parsing(value): " + td.input);
     }
   }
 
@@ -101,7 +106,8 @@ class JSNativeParserTest {
         exception = e;
       }
       assertNotNull(exception);
-      assertEquals(td.expected.getMessage(), exception.getMessage());
+      assertEquals(td.expected.getMessage(), exception.getMessage(),
+          "Failed parsing(throw): " + td.input);
     }
   }
 

--- a/jstp-core/src/test/java/com/metarhia/jstp/core/JSNativeSerializerTest.java
+++ b/jstp-core/src/test/java/com/metarhia/jstp/core/JSNativeSerializerTest.java
@@ -14,15 +14,17 @@ class JSNativeSerializerTest {
 
   private static final ArrayList<TestData<String, String>> stringifyTestData =
       new ArrayList<>(Arrays.asList(
-//          new TestData<>("{}", "{}"),
-//          new TestData<>("[]", "[]"),
-//          new TestData<>("'abv\\\"gggg\\\"dd'", "'abv\"gggg\"dd'"),
-//          new TestData<>("'abv\"gggg\"dd'", "'abv\"gggg\"dd'"),
-//          new TestData<>("['outer', ['inner']]", "[\'outer\',[\'inner\']]"),
-//          new TestData<>("\'\\u{1F49A}ttt\\u{1F49B}\'", "'💚ttt💛'"),
-//          new TestData<>("'\\x20'", "' '"),
+          new TestData<>("{}", "{}"),
+          new TestData<>("[]", "[]"),
+          new TestData<>("'abv\\\"gggg\\\"dd'", "'abv\"gggg\"dd'"),
+          new TestData<>("'abv\"gggg\"dd'", "'abv\"gggg\"dd'"),
+          new TestData<>("['outer', ['inner']]", "[\'outer\',[\'inner\']]"),
+          new TestData<>("\'\\u{1F49A}ttt\\u{1F49B}\'", "'💚ttt💛'"),
+          new TestData<>("'\\x20'", "' '"),
           new TestData<>("13", "13"),
-          new TestData<>("42.1", "42.1")));
+          new TestData<>("42.1", "42.1")
+      ));
+
   static {
     final TestData[] parseTestData = JSNativeParserTest.parseTestData;
     for (int i = 7; i < parseTestData.length; i++) {
@@ -43,7 +45,7 @@ class JSNativeSerializerTest {
       parser.setInput(td.input);
       Object parsed = parser.parse();
       String actual = JSNativeSerializer.stringify(parsed);
-      assertEquals(td.expected, actual);
+      assertEquals(td.expected, actual, "Failed to parse->stringify: " + td.input);
     }
   }
 }


### PR DESCRIPTION
* throw exception if parser doesn't know how to parse input
* throw separate exception for 'key' in place of value in objects and arrays
* update tests with new error messages
* report error with error index at the beginning of the erroed part
* print input that caused error in parse/serialize tests
* add newlines at the end of files